### PR TITLE
Added docker as a way to run without installing Hugo on your machine …

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,9 @@ Please fork the repository to your own GitHub to make any changes.
 - Download Hugo from [gohugo.io](https://gohugo.io/)
 - In your preferred console, run `hugo -D server`
 - Go to the URL which is returned in the output to see the site!
+
+## Running the Website locally via docker
+
+- Install Docker if you haven't already
+- Run `docker-compose up` or `docker-compose up -d` (for detached mode) 
+- Go to [http://localhost:1313](http://localhost:1313)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.8'
+
+services:
+  womenofdotnet-web:
+    image: yanqd0/hugo
+    volumes:
+      - .:/srv/hugo
+    ports:
+      - 1313:1313


### PR DESCRIPTION
Added the ability to run the site locally via docker/docker compose which negates the need to have Hugo installed locally on a machine.

Updated the readme with instructions